### PR TITLE
fix: prevent git ignore dev-bundle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+!**/dev-bundle/webapp/VAADIN/build
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**
 !**/src/test/**


### PR DESCRIPTION
## Description

The `build` rule prevents part of the dev-bundle from being added to the git repository. This change adds an exclusion to the `.gitignore` file to prevent part of the bundle to be silently ignored
## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
