### PR TITLE
chore: build for production by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ Now you can open the [http://localhost:8080](http://localhost:8080) with your br
 Run the following command in this repo:
 
 ```bash
-./gradlew clean build -Pvaadin.productionMode
+./gradlew clean bootJar
 ```
 
-That will build this app in production mode as a runnable jar archive; please find the jar file in `build/libs/base-starter-spring-gradle*.jar`.
+That will build this app in production mode as a runnable jar archive; please find the jar file in `build/libs/base-starter-spring-gradle.jar`.
 You can run the JAR file with:
 
 ```bash
 cd build/libs/
-java -jar base-starter-spring-gradle*.jar
+java -jar base-starter-spring-gradle.jar
 ```
 
 Now you can open the [http://localhost:8080](http://localhost:8080) with your browser.
@@ -67,5 +67,5 @@ Or Vaadin Gradle Plugin will download Node.js for you automatically if it finds 
 To build your app for production in CI, just run:
 
 ```bash
-./gradlew clean build -Pvaadin.productionMode
+./gradlew clean bootJar
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -34,12 +34,6 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 
-vaadin {
-    productionMode = gradle.startParameter.taskNames.any {
-        ["bootJar", "bootBuildImage"].contains(it)
-    }
-}
-
 dependencyManagement {
 	imports {
 		mavenBom "com.vaadin:vaadin-bom:$vaadinVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		}
 }
 plugins {
-	id 'org.springframework.boot' version '4.0.0-M3'
+	id 'org.springframework.boot' version '4.0.0-RC1'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'java'
 	id 'com.vaadin'
@@ -27,11 +27,17 @@ configurations {
 }
 
 dependencies {
-	implementation('com.vaadin:vaadin-spring-boot-starter')
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	testImplementation('org.springframework.boot:spring-boot-starter-test') {
-		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-	}
+	implementation('com.vaadin:vaadin-spring-boot-starter') {
+        exclude group: 'com.vaadin', module: 'vaadin-dev'
+    }
+	developmentOnly('org.springframework.boot:spring-boot-devtools', 'com.vaadin:vaadin-dev')
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
+}
+
+vaadin {
+    productionMode = gradle.startParameter.taskNames.any {
+        ["bootJar", "bootBuildImage"].contains(it)
+    }
 }
 
 dependencyManagement {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 hilla.active=false
-vaadinVersion=25.0.0-beta4
+vaadinVersion=25.0.0-beta5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 hilla.active=false
-vaadinVersion=25.0.0-beta1
+vaadinVersion=25.0.0-beta4


### PR DESCRIPTION
Removes need to add `-Pvaadin.productionMode` explicitly when building for production to make build more consistent with Maven starters. `productionMode` property is activated with `bootJar` and `bootBuildImage` tasks.

Fixes: #293
