### PR TITLE
Bump Vaadin version to 25.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 hilla.active=false
-vaadinVersion=25.0.0-beta7
+vaadinVersion=25.0.0


### PR DESCRIPTION
## Summary
- Updates Vaadin version from 25.0.0-beta7 to 25.0.0 GA

## Test plan
- Build completes successfully with new version